### PR TITLE
fix: fixed syntax error in write_bangla.sh script

### DIFF
--- a/install-scripts/write_bangla.sh
+++ b/install-scripts/write_bangla.sh
@@ -58,6 +58,7 @@ clear
 
 for pkgs in "${packages[@]}"; do
     install_package "$pkgs" "$log"
+done
 
 
 printf "${action} - Now building ${yellow}Openbangla Keyboard ${end}...\n"


### PR DESCRIPTION
forgot to close the for loop, thats why it wasn't installing the openbangla keyboard. it is necessary to write in bangla.